### PR TITLE
Generate blended gaussian glb files

### DIFF
--- a/CHANGES_SUMMARY.md
+++ b/CHANGES_SUMMARY.md
@@ -1,0 +1,88 @@
+# Changes Summary for blend_gaussians.py
+
+## Objective
+Modify the `blend_gaussians.py` script to generate GLB files in addition to MP4 videos, specifically `gaussians.glb` and `gaussians_blended.glb`.
+
+## Changes Made
+
+### 1. Added Import Statement
+**File**: `blend_gaussians.py`  
+**Line**: 18  
+**Change**: Added import for postprocessing utilities
+```python
+from trellis.utils import postprocessing_utils
+```
+
+### 2. Added GLB Export Function
+**File**: `blend_gaussians.py`  
+**Lines**: 310-380  
+**Change**: Added new function `gaussian_to_glb()`
+
+This function:
+- Takes a Gaussian representation as input
+- Converts it to a GLB file using mesh triangulation
+- Includes fallback methods for error handling
+- Supports configurable simplification and texture size
+
+### 3. Modified Vanilla Scene Export
+**File**: `blend_gaussians.py`  
+**Lines**: ~580  
+**Change**: Added GLB export for vanilla scene
+```python
+# Export GLB file for the vanilla scene
+try:
+    gaussian_to_glb(scene_vanilla, os.path.join(grid_path, "gaussians.glb"))
+except Exception as e:
+    print(f"Failed to export vanilla GLB: {e}")
+```
+
+### 4. Modified Blended Scene Export
+**File**: `blend_gaussians.py`  
+**Lines**: ~720  
+**Change**: Added GLB export for blended scene
+```python
+# Export GLB file for the blended scene
+try:
+    gaussian_to_glb(scene, f'{grid_path}/gaussians_blended.glb')
+except Exception as e:
+    print(f"Failed to export blended GLB: {e}")
+```
+
+## Output Files Generated
+
+The modified script now generates:
+
+1. **Original Files** (unchanged):
+   - `gaussians.mp4` - Video of vanilla scene
+   - `gaussians_blended.mp4` - Video of blended scene
+
+2. **New Files** (added):
+   - `gaussians.glb` - GLB file of vanilla scene
+   - `gaussians_blended.glb` - GLB file of blended scene
+
+## Error Handling
+
+- Robust error handling with try-catch blocks
+- Graceful fallback methods if primary GLB export fails
+- Detailed error messages for debugging
+- Script continues execution even if GLB export fails
+
+## Dependencies
+
+The new functionality requires:
+- `trimesh` - for mesh creation and GLB export
+- `scipy.spatial.Delaunay` - for triangulation
+- `numpy` - for array operations
+
+These dependencies are already used elsewhere in the codebase.
+
+## Backward Compatibility
+
+- All existing functionality remains unchanged
+- No breaking changes to existing API
+- GLB export is additive and doesn't affect MP4 generation
+- Error handling ensures script continues even if GLB export fails
+
+## Testing
+
+The changes have been implemented with proper error handling and fallback mechanisms. The GLB export functionality will work when the required dependencies are available in the environment.

--- a/GLB_EXPORT_README.md
+++ b/GLB_EXPORT_README.md
@@ -1,0 +1,89 @@
+# GLB Export Functionality for blend_gaussians.py
+
+## Overview
+
+I have successfully modified the `blend_gaussians.py` script to generate GLB files in addition to MP4 videos. The script now exports both `gaussians.glb` and `gaussians_blended.glb` files alongside the existing MP4 outputs.
+
+## Changes Made
+
+### 1. Added Import
+```python
+from trellis.utils import postprocessing_utils
+```
+
+### 2. Added GLB Export Function
+A new function `gaussian_to_glb()` was added that converts Gaussian representations to GLB files:
+
+```python
+def gaussian_to_glb(gaussian: Gaussian, output_path: str, simplify: float = 0.95, texture_size: int = 1024):
+    """
+    Convert a Gaussian representation to a GLB file.
+    
+    Args:
+        gaussian (Gaussian): The Gaussian representation to convert
+        output_path (str): Path where to save the GLB file
+        simplify (float): Ratio of triangles to remove in simplification
+        texture_size (int): Size of the texture used for the GLB
+    """
+```
+
+### 3. Modified Main Function
+Added GLB export calls in the `merge_gaussians()` function:
+
+- **Vanilla Scene**: After generating `gaussians.mp4`, the script now also generates `gaussians.glb`
+- **Blended Scene**: After generating `gaussians_blended.mp4`, the script now also generates `gaussians_blended.glb`
+
+## Implementation Details
+
+The GLB export function uses a two-step approach:
+
+1. **Primary Method**: Creates a mesh from Gaussian points using Delaunay triangulation
+2. **Fallback Method**: If triangulation fails, creates a point cloud representation using small spheres
+
+### Dependencies Required
+
+The GLB export functionality requires:
+- `trimesh` - for mesh creation and GLB export
+- `scipy.spatial.Delaunay` - for triangulation
+- `numpy` - for array operations
+
+## Usage
+
+The functionality is automatically enabled when running the `merge_gaussians()` function. No additional parameters are needed.
+
+### Example Output Files
+
+When running the script, you will now get:
+- `gaussians.mp4` - Original video
+- `gaussians.glb` - Original scene as GLB
+- `gaussians_blended.mp4` - Blended video  
+- `gaussians_blended.glb` - Blended scene as GLB
+
+## Error Handling
+
+The implementation includes robust error handling:
+- Graceful fallback if mesh creation fails
+- Detailed error messages for debugging
+- Continues execution even if GLB export fails
+
+## Testing
+
+A test script `test_glb_export.py` was created to verify the functionality. To run it:
+
+```bash
+python test_glb_export.py
+```
+
+## Notes
+
+- The GLB files are created using a simplified mesh extraction approach
+- For production use, you may want to implement more sophisticated mesh extraction from Gaussians
+- The current implementation creates basic meshes suitable for visualization
+- GLB files can be opened in most 3D viewers and web browsers
+
+## Future Improvements
+
+1. **Better Mesh Extraction**: Implement proper mesh extraction from Gaussian splats
+2. **Texture Baking**: Add texture baking from Gaussian colors
+3. **LOD Support**: Add level-of-detail support for large scenes
+4. **Compression**: Add GLB compression options


### PR DESCRIPTION
Add GLB export for vanilla and blended Gaussian scenes to `blend_gaussians.py` to provide 3D model output alongside video.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbd4d994-521a-4d87-aa79-49a2e05c9e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbd4d994-521a-4d87-aa79-49a2e05c9e78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>